### PR TITLE
Feat: Limit plugin to vite build phase and run it at `post` stage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ export default {
 ```
 
 Vite:
+
+> [!NOTE]
+> This will only apply at build time
+
 ```js
 import { obfuscator } from 'rollup-obfuscator';
 import { defineConfig } from 'vite';

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export function obfuscator(options: RollupObfuscatorOptions = {}): Plugin {
 
 	return {
 		name: 'obfuscator',
+		apply: 'build',
+		enforce: 'post',
 
 		transform(code, id) {
 			if (!filter(id)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import { createFilter } from '@rollup/pluginutils';
 import Obfuscator from 'javascript-obfuscator';
 import type { Plugin } from 'rollup';
 
+interface ObfuscatorPlugin extends Plugin {
+	apply?: 'build' | 'serve';
+	enforce?: 'pre' | 'post';
+}
+
 export interface RollupObfuscatorOptions extends ObfuscatorOptions {
 	/**
 	 * A [FilterPattern](https://github.com/rollup/plugins/blob/master/packages/pluginutils/types/index.d.ts#L23) of files to include. By default only allows js/ts files.
@@ -18,7 +23,7 @@ export interface RollupObfuscatorOptions extends ObfuscatorOptions {
 	exclude?: FilterPattern;
 }
 
-export function obfuscator(options: RollupObfuscatorOptions = {}): Plugin {
+export function obfuscator(options: RollupObfuscatorOptions = {}): ObfuscatorPlugin {
 	const {
 		include = ['**/*.js', '**/*.ts'],
 		exclude = ['node_modules/**'],


### PR DESCRIPTION
Using `enforce` property of the vite-plugin interface to put the execution of the obfuscation after other vite plugins. Could resolve #144 if merged.