### PR TITLE
fix: optional chaining for this.debug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,11 +40,11 @@ export function obfuscator(options: RollupObfuscatorOptions = {}): ObfuscatorPlu
 
 		transform(code, id) {
 			if (!filter(id)) {
-				this?.debug(`[rollup-obfuscator] Ignoring "${id}"`);
+				this.debug?.(`[rollup-obfuscator] Ignoring "${id}"`);
 				return null;
 			}
 
-			this?.debug(`[rollup-obfuscator] Obfuscating "${id}"`);
+			this.debug?.(`[rollup-obfuscator] Obfuscating "${id}"`);
 
 			const result = Obfuscator.obfuscate(code, {
 				stringArray: false,


### PR DESCRIPTION
https://github.com/ghostdevv/rollup-obfuscator/issues/148

Apologies if I'm missing something obvious--this is my first contribution. But I assume that the code here represents the intended optional chaining?